### PR TITLE
OUT-3157 fix property TextPositionManuallySet

### DIFF
--- a/RxBim.NetDxf/Entities/Dimension.cs
+++ b/RxBim.NetDxf/Entities/Dimension.cs
@@ -111,6 +111,7 @@ namespace netDxf.Entities
         private double lineSpacing;
         private double elevation;
         private readonly DimensionStyleOverrideDictionary styleOverrides;
+        private bool userTextPosition;
 
         #endregion
 
@@ -160,7 +161,15 @@ namespace netDxf.Entities
         /// <summary>
         /// Gets or sets if the text reference point has been set by the user. Set to false to reset the dimension text to its original position.
         /// </summary>
-        public bool TextPositionManuallySet { get; set; }
+        /// <remarks>
+        /// Attention! This method returns the value of the <see cref="userTextPosition"/> field,
+        /// which can be changed when the <see cref="TextReferencePoint"/> is set
+        /// </remarks>
+        public bool TextPositionManuallySet
+        {
+            get => userTextPosition;
+            set => userTextPosition = value;
+        }
 
         /// <summary>
         /// Gets or sets the text reference <see cref="Vector2">position</see>, the middle point of dimension text in local coordinates.
@@ -170,11 +179,16 @@ namespace netDxf.Entities
         /// If the style FitTextMove is set to BesidesDimLine the text reference point will take precedence over the offset value to place the dimension line.
         /// In case of Ordinate dimensions if the text has been manually set the text position will take precedence over the EndLeaderPoint only if FitTextMove
         /// has been set to OverDimLineWithoutLeader.
+        /// Attention! this method sets TextReferencePoint = true!
         /// </remarks>
         public Vector2 TextReferencePoint
         {
-            get => this.textRefPoint;
-            set => this.textRefPoint = value;
+            get => textRefPoint;
+            set
+            {
+                userTextPosition = true;
+                textRefPoint = value;
+            }
         }
 
         /// <summary>
@@ -350,6 +364,14 @@ namespace netDxf.Entities
         }
 
         #endregion
+
+        /// <summary>
+        /// Changes <see cref="textRefPoint"/> without changing the  <see cref="userTextPosition"/>>
+        /// </summary>
+        internal void SetTextReferencePoint(Vector2 point)
+        {
+            textRefPoint = point;
+        }
 
         #region Dimension style overrides events
 

--- a/RxBim.NetDxf/Entities/Dimension.cs
+++ b/RxBim.NetDxf/Entities/Dimension.cs
@@ -179,7 +179,7 @@ namespace netDxf.Entities
         /// If the style FitTextMove is set to BesidesDimLine the text reference point will take precedence over the offset value to place the dimension line.
         /// In case of Ordinate dimensions if the text has been manually set the text position will take precedence over the EndLeaderPoint only if FitTextMove
         /// has been set to OverDimLineWithoutLeader.
-        /// Attention! this method sets TextReferencePoint = true!
+        /// Attention! this property sets <see cref="userTextPosition"/> = true!
         /// </remarks>
         public Vector2 TextReferencePoint
         {
@@ -365,13 +365,17 @@ namespace netDxf.Entities
 
         #endregion
 
+        #region internal methods
+        
         /// <summary>
-        /// Changes <see cref="textRefPoint"/> without changing the  <see cref="userTextPosition"/>>
+        /// Changes <see cref="textRefPoint"/> without changing the <see cref="userTextPosition"/>>
         /// </summary>
         internal void SetTextReferencePoint(Vector2 point)
         {
             textRefPoint = point;
         }
+        
+        #endregion
 
         #region Dimension style overrides events
 

--- a/RxBim.NetDxf/Entities/Dimension.cs
+++ b/RxBim.NetDxf/Entities/Dimension.cs
@@ -111,7 +111,6 @@ namespace netDxf.Entities
         private double lineSpacing;
         private double elevation;
         private readonly DimensionStyleOverrideDictionary styleOverrides;
-        private bool userTextPosition;
 
         #endregion
 
@@ -161,11 +160,7 @@ namespace netDxf.Entities
         /// <summary>
         /// Gets or sets if the text reference point has been set by the user. Set to false to reset the dimension text to its original position.
         /// </summary>
-        public bool TextPositionManuallySet
-        {
-            get { return this.userTextPosition; }
-            set { this.userTextPosition = value; }
-        }
+        public bool TextPositionManuallySet { get; set; }
 
         /// <summary>
         /// Gets or sets the text reference <see cref="Vector2">position</see>, the middle point of dimension text in local coordinates.
@@ -178,12 +173,8 @@ namespace netDxf.Entities
         /// </remarks>
         public Vector2 TextReferencePoint
         {
-            get { return this.textRefPoint; }
-            set
-            {
-                this.userTextPosition = true;
-                this.textRefPoint = value;
-            }
+            get => this.textRefPoint;
+            set => this.textRefPoint = value;
         }
 
         /// <summary>

--- a/RxBim.NetDxf/Entities/DimensionBlock.cs
+++ b/RxBim.NetDxf/Entities/DimensionBlock.cs
@@ -790,7 +790,7 @@ namespace netDxf.Entities
                 }
             }
 
-            dim.TextReferencePoint = textRef + gap * vec;
+            dim.SetTextReferencePoint(textRef + gap * vec);
 
             // drawing block
             return new Block(name, entities, null, false) {Flags = BlockTypeFlags.AnonymousBlock};
@@ -885,7 +885,7 @@ namespace netDxf.Entities
                     {
                         var newRefPoint = middlePoint +
                                           dirRef1 * (2 * style.ExtLineExtend + style.TextOffset + style.TextHeight / 2);
-                        dim.TextReferencePoint = newRefPoint;
+                        dim.SetTextReferencePoint(newRefPoint);
                     }
 
                     var thirdVector2 = Vector2.Normalize(dimRef2 - middlePoint);
@@ -907,7 +907,7 @@ namespace netDxf.Entities
                 }
                 else
                 {
-                    dim.TextReferencePoint += gap * vec;
+                    dim.SetTextReferencePoint(dim.TextReferencePoint + gap * vec);
                     entities.Add(mText);
                 }
             }
@@ -1033,7 +1033,7 @@ namespace netDxf.Entities
                 entities.Add(mText);
             }
 
-            dim.TextReferencePoint = position;
+            dim.SetTextReferencePoint(position);
 
             // drawing block
             return new Block(name, entities, null, false) {Flags = BlockTypeFlags.AnonymousBlock};
@@ -1146,7 +1146,7 @@ namespace netDxf.Entities
                 entities.Add(mText);
             }
 
-            dim.TextReferencePoint = position;
+            dim.SetTextReferencePoint(position);
 
             // drawing block
             return new Block(name, entities, null, false) { Flags = BlockTypeFlags.AnonymousBlock };
@@ -1264,7 +1264,7 @@ namespace netDxf.Entities
                 entities.Add(mText);
             }
 
-            dim.TextReferencePoint = textPos;
+            dim.SetTextReferencePoint(textPos);
 
             return new Block(name, entities, null, false) {Flags = BlockTypeFlags.AnonymousBlock};
         }
@@ -1374,7 +1374,7 @@ namespace netDxf.Entities
                 entities.Add(mText);
             }
 
-            dim.TextReferencePoint = textPos;
+            dim.SetTextReferencePoint(textPos);
 
             return new Block(name, entities, null, false) {Flags = BlockTypeFlags.AnonymousBlock};
 
@@ -1476,7 +1476,7 @@ namespace netDxf.Entities
                 entities.Add(mText);
             }
 
-            dim.TextReferencePoint = midText;
+            dim.SetTextReferencePoint(midText);
 
             // drawing block
             return new Block(name, entities, null, false) {Flags = BlockTypeFlags.AnonymousBlock};
@@ -1590,7 +1590,7 @@ namespace netDxf.Entities
                 entities.Add(mText);
             }
 
-            dim.TextReferencePoint = position;
+            dim.SetTextReferencePoint(position);
 
             // drawing block
             return new Block(name, entities, null, false) { Flags = BlockTypeFlags.AnonymousBlock };

--- a/RxBim.NetDxf/Entities/DimensionBlock.cs
+++ b/RxBim.NetDxf/Entities/DimensionBlock.cs
@@ -791,7 +791,6 @@ namespace netDxf.Entities
             }
 
             dim.TextReferencePoint = textRef + gap * vec;
-            dim.TextPositionManuallySet = false;
 
             // drawing block
             return new Block(name, entities, null, false) {Flags = BlockTypeFlags.AnonymousBlock};
@@ -1035,7 +1034,6 @@ namespace netDxf.Entities
             }
 
             dim.TextReferencePoint = position;
-            dim.TextPositionManuallySet = false;
 
             // drawing block
             return new Block(name, entities, null, false) {Flags = BlockTypeFlags.AnonymousBlock};
@@ -1149,7 +1147,6 @@ namespace netDxf.Entities
             }
 
             dim.TextReferencePoint = position;
-            dim.TextPositionManuallySet = false;
 
             // drawing block
             return new Block(name, entities, null, false) { Flags = BlockTypeFlags.AnonymousBlock };
@@ -1268,7 +1265,6 @@ namespace netDxf.Entities
             }
 
             dim.TextReferencePoint = textPos;
-            dim.TextPositionManuallySet = false;
 
             return new Block(name, entities, null, false) {Flags = BlockTypeFlags.AnonymousBlock};
         }
@@ -1379,7 +1375,6 @@ namespace netDxf.Entities
             }
 
             dim.TextReferencePoint = textPos;
-            dim.TextPositionManuallySet = false;
 
             return new Block(name, entities, null, false) {Flags = BlockTypeFlags.AnonymousBlock};
 
@@ -1482,7 +1477,6 @@ namespace netDxf.Entities
             }
 
             dim.TextReferencePoint = midText;
-            dim.TextPositionManuallySet = false;
 
             // drawing block
             return new Block(name, entities, null, false) {Flags = BlockTypeFlags.AnonymousBlock};
@@ -1597,7 +1591,6 @@ namespace netDxf.Entities
             }
 
             dim.TextReferencePoint = position;
-            dim.TextPositionManuallySet = false;
 
             // drawing block
             return new Block(name, entities, null, false) { Flags = BlockTypeFlags.AnonymousBlock };


### PR DESCRIPTION
Problem:

We have a problem with the fact that when adding a LinearDimension to a document, the TextPositionManuallySet property is set to true. This entails errors during further changes in the document, including rotation.

Solution: 
The issue is caused by the fact that when the setter for the TextReferencePoint property is called, the userTextPosition field is set to true. The TextPositionManuallySet property returns the value of the userTextPosition field.

It seems that it was initially planned that when the text position (TextReferencePoint) is set, it would indicate that the user has selected a position for the text. However, the setter for TextReferencePoint is ultimately used in utility code when creating a DimensionBlock, which leads to the automatic setting of TextPositionManuallySet to true.

In almost all instances in the code, the line following the setting of TextReferencePoint sets the TextPositionManuallySet property to false (probably as a workaround). The only place where this is not done (during the creation of DimensionBlock for LinearDimension) is where our bug, described at the beginning, occurs.

The solution is to remove the confusing behavior (this.userTextPosition = true;).